### PR TITLE
[RFC] feat: add support for strongly typed exp/gates

### DIFF
--- a/Sample/App/Examples/EmptySynchronousSpecs.json
+++ b/Sample/App/Examples/EmptySynchronousSpecs.json
@@ -1,0 +1,10 @@
+{
+  "dynamic_configs": [],
+  "feature_gates": [],
+  "id_lists": {
+  },
+  "layers": {},
+  "layer_configs": [],
+  "has_updates": true,
+  "time": 1697131166636
+}

--- a/Sample/App/Examples/ExampleDirectoryViewController.swift
+++ b/Sample/App/Examples/ExampleDirectoryViewController.swift
@@ -8,6 +8,7 @@ let Examples: [(String, UIViewController)] = [
     ( "Synchronous Init (Swift)", SynchronousInitViewController() ),
     ( "Statsig Client Events (Swift)", ClientEventsViewController() ),
     ( "Statsig Global User (Swift)", GlobalUserOnDeviceEvaluationsViewController() ),
+    ( "Strictly Typed Usage (Swift)", TypedStatsigViewController() ),
 
     // Objective C
     ( "Basic (ObjC)", BasicOnDeviceEvaluationsViewControllerObjC() ),

--- a/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
+++ b/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
@@ -2,8 +2,13 @@ import Foundation
 import StatsigOnDeviceEvaluations
 
 @objc class SdkDemoGates: NSObject {
-    @objc static let aGate = TypedGateName("a_gate")
+    @objc static let aGate = TypedGateName("a_gate", isMemoizable: true)
     @objc static let partialGate = TypedGateName("partial_gate")
+}
+
+public enum SdkDemoSimpleGroupName: String, TypedGroupName {
+    case control = "Control"
+    case test = "Test"
 }
 
 class SdkDemoExperiments {
@@ -13,13 +18,8 @@ class SdkDemoExperiments {
 
 struct SdkDemoTypedAnExperiment: TypedExperimentMemoizedByUserID {
     static var name = "an_experiment"
-    
-    var groupName: SdkDemoTypedAnExperimentGroup?
-    enum SdkDemoTypedAnExperimentGroup: String, TypedGroupName {
-        case control = "Control"
-        case test = "Test"
-    }
 
+    var groupName: SdkDemoSimpleGroupName?
     var value: TypedNoValue?
 }
 

--- a/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
+++ b/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
@@ -1,0 +1,57 @@
+import Foundation
+import StatsigOnDeviceEvaluations
+
+public enum SdkDemoExperimentName: String {
+    case empty = ""
+    case anExperiment = "an_experiment"
+    case anotherExperiment = "another_experiment"
+}
+
+public enum SdkDemoDynamicConfigName: String {
+    case empty = ""
+    case aDynamicConfig = "a_dynamic_config"
+}
+
+@objc class SdkDemoGates: NSObject {
+    @objc static let aGate = TypedGateName("a_gate")
+    @objc static let partialGate = TypedGateName("partial_gate")
+}
+
+class SdkDemoExperiments {
+    static let AnExperiment = SdkDemoTypedAnExperiment.self
+    static let AnotherExperiment = SdkDemoTypedAnotherExperiment.self
+}
+
+struct SdkDemoTypedAnExperiment: TypedExperiment {
+    static var name = "an_experiment"
+    
+    var groupName: SdkDemoTypedAnExperimentGroup?
+    enum SdkDemoTypedAnExperimentGroup: String, TypedGroupName {
+        case control = "Control"
+        case test = "Test"
+    }
+    
+    var value: TypedNoValue?
+}
+
+struct SdkDemoTypedAnotherExperiment: TypedExperiment {
+    static var name = "another_experiment"
+    
+    var groupName: SdkDemoTypedAnotherExperimentGroup?
+    enum SdkDemoTypedAnotherExperimentGroup: String, TypedGroupName {
+        case control = "Control"
+        case testOne = "Test One"
+        case testTwo = "Test Two"
+    }
+    
+    var value: AnotherExperimentValue?
+    struct AnotherExperimentValue: Decodable {
+        let aString: String
+        let aBool: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case aString = "a_string"
+            case aBool = "a_bool"
+        }
+    }
+}

--- a/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
+++ b/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
@@ -1,17 +1,6 @@
 import Foundation
 import StatsigOnDeviceEvaluations
 
-public enum SdkDemoExperimentName: String {
-    case empty = ""
-    case anExperiment = "an_experiment"
-    case anotherExperiment = "another_experiment"
-}
-
-public enum SdkDemoDynamicConfigName: String {
-    case empty = ""
-    case aDynamicConfig = "a_dynamic_config"
-}
-
 @objc class SdkDemoGates: NSObject {
     @objc static let aGate = TypedGateName("a_gate")
     @objc static let partialGate = TypedGateName("partial_gate")
@@ -24,6 +13,8 @@ class SdkDemoExperiments {
 
 struct SdkDemoTypedAnExperiment: TypedExperiment {
     static var name = "an_experiment"
+    static var isMemoizable = true
+    static var memoUnitIdType = "userID"
     
     var groupName: SdkDemoTypedAnExperimentGroup?
     enum SdkDemoTypedAnExperimentGroup: String, TypedGroupName {

--- a/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
+++ b/Sample/App/Examples/OnDeviceEvaluations/SdkDemoTypes.swift
@@ -11,17 +11,15 @@ class SdkDemoExperiments {
     static let AnotherExperiment = SdkDemoTypedAnotherExperiment.self
 }
 
-struct SdkDemoTypedAnExperiment: TypedExperiment {
+struct SdkDemoTypedAnExperiment: TypedExperimentMemoizedByUserID {
     static var name = "an_experiment"
-    static var isMemoizable = true
-    static var memoUnitIdType = "userID"
     
     var groupName: SdkDemoTypedAnExperimentGroup?
     enum SdkDemoTypedAnExperimentGroup: String, TypedGroupName {
         case control = "Control"
         case test = "Test"
     }
-    
+
     var value: TypedNoValue?
 }
 

--- a/Sample/App/Examples/OnDeviceEvaluations/TypedStatsigViewController.swift
+++ b/Sample/App/Examples/OnDeviceEvaluations/TypedStatsigViewController.swift
@@ -1,0 +1,101 @@
+import UIKit
+import StatsigOnDeviceEvaluations
+
+class TypedStatsigViewController: UIViewController {
+    let user = StatsigUser(userID: "a-user")
+    let statsig = Statsig()
+    
+    override func loadView() {
+        super.loadView()
+        view.backgroundColor = UIColor.white
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        statsig.initialize(Constants.CLIENT_SDK_KEY) { [weak self] err in
+            if let err = err {
+                print("Error \(err)")
+            }
+            
+            DispatchQueue.main.async {
+                self?.render()
+            }
+        }
+    }
+    
+    func render() {
+        var texts = ["- Strict Typing -"]
+        
+        // Get an Experiment using strict typing
+        let anExperiment = statsig.typed.getExperiment(SdkDemoExperiments.AnExperiment, user)
+        switch anExperiment.groupName {
+        case .test:
+            texts.append("\(anExperiment.name): Test Group")
+            break
+            
+        case .none:
+            fallthrough
+        case .control:
+            texts.append("\(anExperiment.name): Control Group")
+            break
+        }
+        
+        // Get an Experiment (with params) using strict typing
+        let anotherExperiment = statsig.typed.getExperiment(SdkDemoExperiments.AnotherExperiment, user)
+        let value = anotherExperiment.value
+        texts.append("\(anotherExperiment.name): \(value?.aString ?? "Err") - \(value?.aBool == true ? "Pass" : "Fail")")
+        
+        // Get a Feature Gate using strict typing
+        let aGate = statsig.typed.getFeatureGate(SdkDemoGates.aGate, user)
+        texts.append("\(aGate.name): \(aGate.value ? "Pass": "Fail")")
+
+        // Render labels
+        let labels = texts.map { createLabel(text: $0) }
+        labels.forEach { view.addSubview($0) }
+        setupConstraints(for: labels)
+    }
+    
+    private func createLabel(text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+    
+    private func setupConstraints(for labels: [UILabel]) {
+        guard !labels.isEmpty else { return }
+        
+        var constraints: [NSLayoutConstraint] = []
+        
+        for (index, label) in labels.enumerated() {
+            if index == 0 {
+                // First label is centered vertically
+                constraints.append(contentsOf: setupLabelConstraints(label, centerYOffset: -CGFloat(20 * (labels.count - 1))))
+            } else {
+                // Subsequent labels are positioned relative to the previous label
+                constraints.append(contentsOf: setupLabelConstraints(label, topAnchor: labels[index - 1].bottomAnchor))
+            }
+        }
+        
+        NSLayoutConstraint.activate(constraints)
+    }
+    
+    private func setupLabelConstraints(_ label: UILabel, centerYOffset: CGFloat? = nil, topAnchor: NSLayoutYAxisAnchor? = nil) -> [NSLayoutConstraint] {
+        var constraints = [
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
+        ]
+        
+        if let centerYOffset = centerYOffset {
+            constraints.append(label.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: centerYOffset))
+        } else if let topAnchor = topAnchor {
+            constraints.append(label.topAnchor.constraint(equalTo: topAnchor, constant: 20))
+        }
+        
+        return constraints
+    }
+}
+

--- a/Sample/StatsigSamples.xcodeproj/project.pbxproj
+++ b/Sample/StatsigSamples.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5CD93AB02AF953C2009A5898 /* StatsigSamplesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD93AAF2AF953C2009A5898 /* StatsigSamplesTests.swift */; };
 		5CDBFC9A2AD4EFE0002E6E60 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDBFC992AD4EFE0002E6E60 /* AppDelegate.swift */; };
 		5CDBFC9E2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDBFC9D2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift */; };
+		5CE7C4682CC8289500FD64F2 /* EmptySynchronousSpecs.json in Resources */ = {isa = PBXBuildFile; fileRef = 5CE7C4672CC8289500FD64F2 /* EmptySynchronousSpecs.json */; };
 		5CE8F8B02ADB772C0075CA71 /* SynchronousInitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE8F8AF2ADB772C0075CA71 /* SynchronousInitViewController.swift */; };
 		5CE8F8B22ADB9C130075CA71 /* SynchronousSpecs.json in Resources */ = {isa = PBXBuildFile; fileRef = 5CE8F8B12ADB9C130075CA71 /* SynchronousSpecs.json */; };
 		5CFB0C932CC055DA00F1B1FF /* TypedStatsigViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB0C922CC055DA00F1B1FF /* TypedStatsigViewController.swift */; };
@@ -59,6 +60,7 @@
 		5CDBFC992AD4EFE0002E6E60 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5CDBFC9D2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicOnDeviceEvaluationsViewController.swift; sourceTree = "<group>"; };
 		5CDBFCA72AD4EFE1002E6E60 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5CE7C4672CC8289500FD64F2 /* EmptySynchronousSpecs.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = EmptySynchronousSpecs.json; sourceTree = "<group>"; };
 		5CE8F8AF2ADB772C0075CA71 /* SynchronousInitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronousInitViewController.swift; sourceTree = "<group>"; };
 		5CE8F8B12ADB9C130075CA71 /* SynchronousSpecs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SynchronousSpecs.json; sourceTree = "<group>"; };
 		5CFB0C922CC055DA00F1B1FF /* TypedStatsigViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedStatsigViewController.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 		5C8094622ADF19D1001AF600 /* Examples */ = {
 			isa = PBXGroup;
 			children = (
+				5CE7C4672CC8289500FD64F2 /* EmptySynchronousSpecs.json */,
 				5CE8F8B12ADB9C130075CA71 /* SynchronousSpecs.json */,
 				5C8094632ADF19DA001AF600 /* OnDeviceEvaluations */,
 				5C68BFBB2AFAD3D6006FD9B5 /* ExampleDirectoryViewController.swift */,
@@ -264,6 +267,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CE7C4682CC8289500FD64F2 /* EmptySynchronousSpecs.json in Resources */,
 				5CE8F8B22ADB9C130075CA71 /* SynchronousSpecs.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sample/StatsigSamples.xcodeproj/project.pbxproj
+++ b/Sample/StatsigSamples.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		5CDBFC9E2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDBFC9D2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift */; };
 		5CE8F8B02ADB772C0075CA71 /* SynchronousInitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE8F8AF2ADB772C0075CA71 /* SynchronousInitViewController.swift */; };
 		5CE8F8B22ADB9C130075CA71 /* SynchronousSpecs.json in Resources */ = {isa = PBXBuildFile; fileRef = 5CE8F8B12ADB9C130075CA71 /* SynchronousSpecs.json */; };
+		5CFB0C932CC055DA00F1B1FF /* TypedStatsigViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB0C922CC055DA00F1B1FF /* TypedStatsigViewController.swift */; };
+		5CFB0C952CC0583000F1B1FF /* SdkDemoTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFB0C942CC0583000F1B1FF /* SdkDemoTypes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -59,6 +61,8 @@
 		5CDBFCA72AD4EFE1002E6E60 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5CE8F8AF2ADB772C0075CA71 /* SynchronousInitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronousInitViewController.swift; sourceTree = "<group>"; };
 		5CE8F8B12ADB9C130075CA71 /* SynchronousSpecs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SynchronousSpecs.json; sourceTree = "<group>"; };
+		5CFB0C922CC055DA00F1B1FF /* TypedStatsigViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedStatsigViewController.swift; sourceTree = "<group>"; };
+		5CFB0C942CC0583000F1B1FF /* SdkDemoTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkDemoTypes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,11 +114,13 @@
 				5CAFD04D2ADAEEDD00ACAF79 /* PerfOnDeviceEvaluationsViewControllerObjC.h */,
 				5CAFD04E2ADAEEDD00ACAF79 /* PerfOnDeviceEvaluationsViewControllerObjC.m */,
 				5CE8F8AF2ADB772C0075CA71 /* SynchronousInitViewController.swift */,
+				5CFB0C922CC055DA00F1B1FF /* TypedStatsigViewController.swift */,
 				5CDBFC9D2AD4EFE0002E6E60 /* BasicOnDeviceEvaluationsViewController.swift */,
 				5CAE022F2B0EEA95008C0888 /* ClientEventsViewControllerObjC.h */,
 				5CAE02302B0EEA95008C0888 /* ClientEventsViewControllerObjC.m */,
 				5CC5773F2CB8579700D2CC7F /* SpecUpdatesViewControllerObjC.h */,
 				5CC577402CB8579700D2CC7F /* SpecUpdatesViewControllerObjC.m */,
+				5CFB0C942CC0583000F1B1FF /* SdkDemoTypes.swift */,
 			);
 			path = OnDeviceEvaluations;
 			sourceTree = "<group>";
@@ -277,6 +283,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5CFB0C932CC055DA00F1B1FF /* TypedStatsigViewController.swift in Sources */,
 				5C10DDA92AD4FB60003C4CE1 /* BasicOnDeviceEvaluationsViewControllerObjC.m in Sources */,
 				5CE8F8B02ADB772C0075CA71 /* SynchronousInitViewController.swift in Sources */,
 				5CAFD04F2ADAEEDD00ACAF79 /* PerfOnDeviceEvaluationsViewControllerObjC.m in Sources */,
@@ -285,6 +292,7 @@
 				5CAE022E2B0ECF44008C0888 /* GlobalUserOnDeviceEvaluationsViewController.swift in Sources */,
 				5C68BFBE2AFAE1FE006FD9B5 /* ClientEventsViewController.swift in Sources */,
 				5CDBFC9A2AD4EFE0002E6E60 /* AppDelegate.swift in Sources */,
+				5CFB0C952CC0583000F1B1FF /* SdkDemoTypes.swift in Sources */,
 				5CC577412CB8579700D2CC7F /* SpecUpdatesViewControllerObjC.m in Sources */,
 				5C68BFBC2AFAD3D6006FD9B5 /* ExampleDirectoryViewController.swift in Sources */,
 				5CAE02312B0EEA95008C0888 /* ClientEventsViewControllerObjC.m in Sources */,

--- a/Sources/StatsigOnDeviceEvaluations/Configs/DynamicConfig.swift
+++ b/Sources/StatsigOnDeviceEvaluations/Configs/DynamicConfig.swift
@@ -4,16 +4,20 @@ import Foundation
 public class DynamicConfig: ConfigBase {
     @objc public let value: [String: Any]
     @objc public let groupName: String?
+    
+    let rawValue: Data?
 
     internal init(
         name: String,
         ruleID: String,
         evaluationDetails: EvaluationDetails,
         value: [String: Any]?,
+        rawValue: Data?,
         groupName: String?
     ) {
         self.value = value ?? [:]
         self.groupName = groupName
+        self.rawValue = rawValue
         super.init(
             name,
             ruleID,
@@ -30,6 +34,7 @@ public class DynamicConfig: ConfigBase {
             ruleID: "",
             evaluationDetails: evalDetails,
             value: nil,
+            rawValue: nil,
             groupName: nil
         )
     }
@@ -44,6 +49,7 @@ public class DynamicConfig: ConfigBase {
             ruleID: "",
             evaluationDetails: EvaluationDetails.empty(),
             value: value,
+            rawValue: nil,
             groupName: nil
         )
     }

--- a/Sources/StatsigOnDeviceEvaluations/Configs/Experiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/Configs/Experiment.swift
@@ -5,15 +5,19 @@ public class Experiment: ConfigBase {
     @objc public let value: [String: Any]
     @objc public let groupName: String?
     
+    let rawValue: Data?
+    
     internal init(
         name: String,
         ruleID: String,
         evaluationDetails: EvaluationDetails,
         value: [String: Any]?,
+        rawValue: Data?,
         groupName: String?
     ) {
         self.value = value ?? [:]
         self.groupName = groupName
+        self.rawValue = rawValue
         super.init(
             name,
             ruleID,
@@ -30,6 +34,7 @@ public class Experiment: ConfigBase {
             ruleID: "",
             evaluationDetails: evalDetails,
             value: nil,
+            rawValue: nil,
             groupName: nil
         )
     }
@@ -44,6 +49,7 @@ public class Experiment: ConfigBase {
             ruleID: "",
             evaluationDetails: EvaluationDetails.empty(),
             value: value,
+            rawValue: nil,
             groupName: nil
         )
     }

--- a/Sources/StatsigOnDeviceEvaluations/Configs/Layer.swift
+++ b/Sources/StatsigOnDeviceEvaluations/Configs/Layer.swift
@@ -5,9 +5,11 @@ typealias ParameterExposureFunc = (_ layer: Layer, _ parameter: String) -> Void
 @objc
 public class Layer: ConfigBase {
     @objc public let value: [String: Any]
-    let logParameterExposure: ParameterExposureFunc?
     @objc public let allocatedExperimentName: String?
     @objc public let groupName: String?
+    
+    let logParameterExposure: ParameterExposureFunc?
+    let rawValue: Data?
 
     internal init(
         name: String,
@@ -15,6 +17,7 @@ public class Layer: ConfigBase {
         evaluationDetails: EvaluationDetails,
         logParameterExposure: ParameterExposureFunc?,
         value: [String: Any]?,
+        rawValue: Data?,
         allocatedExperimentName: String? = nil,
         groupName: String? = nil
     ) {
@@ -22,6 +25,7 @@ public class Layer: ConfigBase {
         self.logParameterExposure = logParameterExposure
         self.allocatedExperimentName = allocatedExperimentName
         self.groupName = groupName
+        self.rawValue = rawValue
 
         super.init(
             name,
@@ -39,7 +43,8 @@ public class Layer: ConfigBase {
             ruleID: "",
             evaluationDetails: evalDetails,
             logParameterExposure: nil,
-            value: nil
+            value: nil,
+            rawValue: nil
         )
     }
     
@@ -53,7 +58,8 @@ public class Layer: ConfigBase {
             ruleID: "",
             evaluationDetails: EvaluationDetails.empty(),
             logParameterExposure: nil,
-            value: value
+            value: value,
+            rawValue: nil
         )
     }
 

--- a/Sources/StatsigOnDeviceEvaluations/Network/JsonValue.swift
+++ b/Sources/StatsigOnDeviceEvaluations/Network/JsonValue.swift
@@ -109,24 +109,30 @@ extension JsonValue: Encodable {
 
 }
 
+public struct SerializedDictionaryResult {
+    let dictionary: [String: Any]?
+    let raw: Data
+}
 
 // MARK: Out Conversion
 extension JsonValue {
-    public func serializeToDictionary() -> [String: Any]? {
+    public func getSerializedDictionaryResult() -> SerializedDictionaryResult? {
         guard case .dictionary(let dictionary) = self else {
             return nil
         }
 
-        do {
-            let encoder = JSONEncoder()
-            let data = try! encoder.encode(dictionary)
-            return try JSONSerialization.jsonObject(
-                with: data,
-                options: []
-            ) as? [String: Any]
-        } catch {
+        let encoder = JSONEncoder()
+        
+        guard let data = try? encoder.encode(dictionary) else {
             return nil
         }
+
+        let json = try? JSONSerialization.jsonObject(
+            with: data,
+            options: []
+        ) as? [String: Any]
+        
+        return SerializedDictionaryResult(dictionary: json, raw: data)
     }
 
     public func asJsonArray() -> [JsonValue]? {

--- a/Sources/StatsigOnDeviceEvaluations/Statsig.swift
+++ b/Sources/StatsigOnDeviceEvaluations/Statsig.swift
@@ -36,8 +36,8 @@ public final class Statsig: NSObject {
     @objc
     public private(set) var typed = TypedStatsigProvider()
 
-    let emitter = StatsigClientEventEmitter()
-    var context: StatsigContext?
+    internal let emitter = StatsigClientEventEmitter()
+    internal var context: StatsigContext?
     internal var minBackgroundSyncInterval = Constants.MIN_BG_SYNC_INTERVAL_SECONDS
 
     @objc(sharedInstance)

--- a/Sources/StatsigOnDeviceEvaluations/StatsigOptions.swift
+++ b/Sources/StatsigOnDeviceEvaluations/StatsigOptions.swift
@@ -60,7 +60,7 @@ import Foundation
      * When bootstrapping (initializeSync or updateSync), set this flag if you would like to use cache values if they are "fresher" then the bootstrap values
      */
     @objc public var useNewerCacheValuesOverProvidedValues: Bool = false
-    
+
     public override init() {
         environment = StatsigEnvironment()
     }

--- a/Sources/StatsigOnDeviceEvaluations/StatsigUserInternal.swift
+++ b/Sources/StatsigOnDeviceEvaluations/StatsigUserInternal.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+extension StatsigUser {
+    internal func getUnitID(_ type: String) -> String? {
+        let lowered = type.lowercased()
+
+        if lowered == "userid" {
+            return self.userID
+        }
+
+        return self.customIDs[type] ?? self.customIDs[lowered]
+    }
+}
+
 struct StatsigUserInternal {
     let user: StatsigUser
     let environment: StatsigEnvironment?
@@ -9,13 +21,7 @@ struct StatsigUserInternal {
     }
 
     internal func getUnitID(_ type: String) -> String? {
-        let lowered = type.lowercased()
-
-        if lowered == "userid" {
-            return user.userID
-        }
-
-        return user.customIDs[type] ?? user.customIDs[lowered]
+        return self.user.getUnitID(type)
     }
 
     internal func getFromEnvironment(_ field: String?) -> JsonValue? {

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
@@ -57,3 +57,34 @@ extension TypedExperiment {
         self.init(groupName: groupName, value: value)
     }
 }
+
+
+// MARK: UserID + Memoization
+
+public protocol TypedExperimentMemoizedByUserID: TypedExperiment {}
+
+extension TypedExperimentMemoizedByUserID {
+    public static var isMemoizable: Bool {
+        return true
+    }
+    
+    public static var memoUnitIdType: String {
+        return "userID"
+    }
+}
+
+
+// MARK: StableID + Memoization
+
+public protocol TypedExperimentMemoizedByStableID: TypedExperiment {}
+
+extension TypedExperimentMemoizedByStableID {
+    public static var isMemoizable: Bool {
+        return true
+    }
+    
+    public static var memoUnitIdType: String {
+        return "stableID"
+    }
+}
+

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
@@ -9,13 +9,24 @@ public struct TypedNoValue: Decodable {}
 public protocol TypedExperiment {
     associatedtype GroupNameType: TypedGroupName
     associatedtype ValueType: Decodable
+    
     static var name: String { get }
+    static var isMemoizable: Bool { get }
+    static var memoUnitIdType: String { get }
 
     init()
     init(groupName: GroupNameType?, value: ValueType?)
 }
 
 extension TypedExperiment {
+    public static var isMemoizable: Bool {
+        return false
+    }
+    
+    public static var memoUnitIdType: String {
+        return ""
+    }
+    
     public var groupName: GroupNameType? {
         get { nil }
         set { }
@@ -28,6 +39,14 @@ extension TypedExperiment {
     
     public var name: String {
         Self.name
+    }
+
+    public var isMemoizable: Bool {
+        Self.isMemoizable
+    }
+    
+    public var memoUnitIdType: String {
+        Self.memoUnitIdType
     }
 
     public init() {

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
@@ -24,7 +24,7 @@ extension TypedExperiment {
     }
     
     public static var memoUnitIdType: String {
-        return ""
+        return "userID"
     }
     
     public var groupName: GroupNameType? {

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
@@ -25,6 +25,10 @@ extension TypedExperiment {
         get { nil }
         set { }
     }
+    
+    public var name: String {
+        Self.name
+    }
 
     public init() {
         self.init(groupName: nil, value: nil)

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedExperiment.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public protocol TypedGroupName {
+    init?(rawValue: String)
+}
+
+public struct TypedNoValue: Decodable {}
+
+public protocol TypedExperiment {
+    associatedtype GroupNameType: TypedGroupName
+    associatedtype ValueType: Decodable
+    static var name: String { get }
+
+    init()
+    init(groupName: GroupNameType?, value: ValueType?)
+}
+
+extension TypedExperiment {
+    public var groupName: GroupNameType? {
+        get { nil }
+        set { }
+    }
+
+    public var value: ValueType? {
+        get { nil }
+        set { }
+    }
+
+    public init() {
+        self.init(groupName: nil, value: nil)
+    }
+
+    public init(_ groupName: GroupNameType, _ value: ValueType) {
+        self.init(groupName: groupName, value: value)
+    }
+}

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedGateName.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedGateName.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@objc public class TypedGateName: NSObject {
+    public let value: String
+
+    public init(_ value: String) {
+        self.value = value
+    }
+}

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedGateName.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedGateName.swift
@@ -2,8 +2,16 @@ import Foundation
 
 @objc public class TypedGateName: NSObject {
     public let value: String
-
-    public init(_ value: String) {
+    public let isMemoizable: Bool
+    public let memoUnitIdType: String
+    
+    public init(
+        _ value: String,
+        isMemoizable: Bool = false,
+        memoUnitIdType: String = "userID"
+    ) {
         self.value = value
+        self.isMemoizable = isMemoizable
+        self.memoUnitIdType = memoUnitIdType
     }
 }

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
@@ -3,44 +3,97 @@ import Foundation
 @objc
 open class TypedStatsigProvider: NSObject {
     var client: Statsig?
-
+    var memoedExperiments: [String: any TypedExperiment] = [:]
+    
     @objc(checkGate:forUser:)
-    open func checkGate(_ key: TypedGateName, _ user: StatsigUser) -> Bool {
+    open func checkGate(_ key: TypedGateName, _ user: StatsigUser? = nil) -> Bool {
         return client?.checkGate(key.value, user) == true
     }
-
+    
     @objc(getFeatureGate:forUser:)
-    open func getFeatureGate(_ key: TypedGateName, _ user: StatsigUser) -> FeatureGate {
+    open func getFeatureGate(_ key: TypedGateName, _ user: StatsigUser? = nil) -> FeatureGate {
         if let client = client {
             return client.getFeatureGate(key.value, user)
         }
-
+        
         return FeatureGate.empty(key.value, .empty())
     }
-
-    open func getExperiment<T: TypedExperiment>(_ type: T.Type, _ user: StatsigUser) -> T {
-        guard
-            let exp = self.client?.getExperiment(type.name, user),
-            let groupName = exp.groupName
-        else {
+    
+    open func getExperiment<T: TypedExperiment>(_ type: T.Type, _ user: StatsigUser? = nil) -> T {
+        guard let client = client, let context = client.context else {
+            self.client?.emitter.emitError("Must initialize Statsig first")
             return T.init()
         }
+        
+        guard let user = user ?? context.globalUser else {
+            client.emitter.emitError("No user given when calling Statsig.typed.getExperiment(::)."
+                              + " Please provide a StatsigUser or call setGlobalUser.")
+            return T.init()
+        }
+        
+        if let found = tryGetMemoExperiment(type, user) {
+            return found
+        }
 
+        let experiment = client.getExperiment(type.name, user)
+        guard let groupName = experiment.groupName else {
+            return tryMemoize(T.init(), user)
+        }
+        
         guard let group = T.GroupNameType.init(rawValue:groupName) else {
             self.client?.emitter.emitError("Failed to convert group name '\(groupName)' to \(T.GroupNameType.self)")
-            return T.init()
+            return tryMemoize(T.init(), user)
         }
-
+        
         var value: T.ValueType? = nil
-        if let raw = exp.rawValue {
+        if let raw = experiment.rawValue {
             let decoder = JSONDecoder()
             value = try? decoder.decode(T.ValueType.self, from: raw)
         }
-
-        return T.init(groupName: group, value: value)
+        
+        return tryMemoize(
+            T.init(groupName: group, value: value),
+            user
+        )
     }
-
+    
     open func bind(_ client: Statsig, _ options: StatsigOptions?) -> Void {
         self.client = client
+        self.memoedExperiments = [:]
     }
 }
+
+
+// MARK: Memoization
+extension TypedStatsigProvider {
+    private func tryGetMemoExperiment<T: TypedExperiment>(
+        _ type: T.Type,
+        _ user: StatsigUser
+    ) -> T? {
+        if !type.isMemoizable {
+            return nil
+        }
+        
+        let key = getMemoKey(user, type.memoUnitIdType, type.name)
+        return memoedExperiments[key] as? T
+    }
+    
+    private func tryMemoize<T: TypedExperiment>(
+        _ instance: T,
+        _ user: StatsigUser
+    ) -> T {
+        if !instance.isMemoizable {
+            return instance
+        }
+
+        let key = getMemoKey(user, instance.memoUnitIdType, instance.name)
+        memoedExperiments[key] = instance
+        return instance
+    }
+    
+    private func getMemoKey(_ user: StatsigUser, _ idType: String, _ name: String) -> String {
+        let idValue = user.getUnitID(idType) ?? "<NONE>"
+        return "\(idType):\(idValue):\(name)"
+    }
+}
+

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+@objc
+open class TypedStatsigProvider: NSObject {
+    var client: Statsig?
+
+    @objc(checkGate:forUser:)
+    open func checkGate(_ key: TypedGateName, _ user: StatsigUser) -> Bool {
+        return client?.checkGate(key.value, user) == true
+    }
+
+    @objc(getFeatureGate:forUser:)
+    open func getFeatureGate(_ key: TypedGateName, _ user: StatsigUser) -> FeatureGate {
+        if let client = client {
+            return client.getFeatureGate(key.value, user)
+        }
+
+        return FeatureGate.empty(key.value, .empty())
+    }
+
+    open func getExperiment<T: TypedExperiment>(_ type: T.Type, _ user: StatsigUser) -> T {
+        guard
+            let exp = self.client?.getExperiment(type.name, user),
+            let groupName = exp.groupName
+        else {
+            return T.init()
+        }
+
+        guard let group = T.GroupNameType.init(rawValue:groupName) else {
+            self.client?.emitter.emitError("Failed to convert group name '\(groupName)' to \(T.GroupNameType.self)")
+            return T.init()
+        }
+
+        var value: T.ValueType? = nil
+        if let raw = exp.rawValue {
+            let decoder = JSONDecoder()
+            value = try? decoder.decode(T.ValueType.self, from: raw)
+        }
+
+        return T.init(groupName: group, value: value)
+    }
+
+    open func bind(_ client: Statsig, _ options: StatsigOptions?) -> Void {
+        self.client = client
+    }
+}

--- a/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
+++ b/Sources/StatsigOnDeviceEvaluations/TypedStatsig/TypedStatsigProvider.swift
@@ -19,7 +19,10 @@ open class TypedStatsigProvider: NSObject {
         return FeatureGate.empty(key.value, .empty())
     }
     
-    open func getExperiment<T: TypedExperiment>(_ type: T.Type, _ user: StatsigUser? = nil) -> T {
+    open func getExperiment<T: TypedExperiment>(
+        _ type: T.Type,
+        _ user: StatsigUser? = nil
+    ) -> T {
         guard let client = client, let context = client.context else {
             self.client?.emitter.emitError("Must initialize Statsig first")
             return T.init()

--- a/Sources/StatsigOnDeviceEvaluations/UserPersistentStorageProvider.swift
+++ b/Sources/StatsigOnDeviceEvaluations/UserPersistentStorageProvider.swift
@@ -79,7 +79,7 @@ extension UserPersistentStorageProvider {
         let data: [String: Any?] = [
             "value": evaluation.boolValue,
             "rule_id": evaluation.ruleID,
-            "json_value": evaluation.jsonValue?.serializeToDictionary(),
+            "json_value": evaluation.jsonValue?.getSerializedDictionaryResult()?.dictionary,
             "secondary_exposures": evaluation.secondaryExposures,
             "explicit_parameters": evaluation.explicitParameters,
             "config_delegate": evaluation.configDelegate,

--- a/Tests/StatsigOnDeviceEvaluationsTestsSwift/JsonValueTest.swift
+++ b/Tests/StatsigOnDeviceEvaluationsTestsSwift/JsonValueTest.swift
@@ -123,11 +123,11 @@ fileprivate func convertInto(
 ) -> Matcher<JsonValue> {
     Matcher.define(matcher: { actualExpression, msg in
         let actual = try! actualExpression.evaluate()
-        if actual?.serializeToDictionary() as NSDictionary? != dictionary {
+        if actual?.getSerializedDictionaryResult()?.dictionary as NSDictionary? != dictionary {
             return MatcherResult(
                 status: .fail,
                 message: .fail(
-                    "Invalid Dictionary. Expected \(String(describing: dictionary)), got \(String(describing: actual?.serializeToDictionary()))"
+                    "Invalid Dictionary. Expected \(String(describing: dictionary)), got \(String(describing: actual?.getSerializedDictionaryResult()?.dictionary))"
                 )
             )
         }


### PR DESCRIPTION
# Update - Oct 28

2d36d5d77320cc2cff8d006402db378557d1ff8d Added support for Feature Gate memoization. You can now specify that a gate should be memoized, as well as what UnitID to memoize on (Defaults to `userID`). 
```swift
class SdkDemoGates {
    static let aGate = TypedGateName("a_gate", isMemoizable: true)
    static let partialGate = TypedGateName(
        "partial_gate",
        isMemoizable: true,
        memoUnitIdType: "stableID"
    )
}
```

e25676d3c3a59f7a2ae4e78fd7538a4dce48afa6 Added default memoized experiment types for UserID (`TypedExperimentMemoizedByUserID`) and StableID (`TypedExperimentMemoizedByStableID`). This removes the need to specify is `isMemoizable` and `memoUnitIdType`

```swift
struct SdkDemoTypedAnExperiment: TypedExperimentMemoizedByUserID {
    static var name = "an_experiment"

    var groupName: SdkDemoSimpleGroupName?
    var value: TypedNoValue?
}
```


Note: `SdkDemoSimpleGroupName` is an enum that only has two groups. It can be shared among many experiments since this is a common setup pattern.

```swift
public enum SdkDemoSimpleGroupName: String, TypedGroupName {
    case control = "Control"
    case test = "Test"
}
```


With this change, a developer can write their own type definitions for Statsig. 
- [Here](https://github.com/statsig-io/swift-on-device-evaluations-sdk/pull/1/files#r1811515031) is an example of a type definitions file for an Sdk Demo project. 
- [Here](https://github.com/statsig-io/swift-on-device-evaluations-sdk/pull/1/files#r1811525906) is an example of the strict types being used.



# Usage

## Gates

A type file is defined by the implementor.

```swift
@objc class SdkDemoGates: NSObject {
    @objc static let aGate = TypedGateName("a_gate")
    @objc static let partialGate = TypedGateName("partial_gate")
}
```

Then the gates can be checked using `Statsig.typed`:
```swift
let gate = Statsig.shared.typed.getFeatureGate(SdkDemoGates.aGate, user)
if gate.value {
    // Do Something
}

if Statsig.shared.typed.checkGate(SdkDemoGates.aGate, user) {
    // Do Something    
}
```

## Experiments

A type file is defined by the implementor.

```swift
class SdkDemoExperiments {
    static let AnExperiment = SdkDemoTypedAnExperiment.self
    static let AnotherExperiment = SdkDemoTypedAnotherExperiment.self
}

struct SdkDemoTypedAnExperiment: TypedExperiment {
    static var name = "an_experiment"
    static var isMemoizable = true
    static var memoUnitIdType = "userID"
    
    var groupName: SdkDemoTypedAnExperimentGroup?
    enum SdkDemoTypedAnExperimentGroup: String, TypedGroupName {
        case control = "Control"
        case test = "Test"
    }
    
    var value: TypedNoValue?
}
```

Then the experiment can be checked using `Statsig.typed`:

```swift
let anExperiment = Statsig.shared.typed.getExperiment(SdkDemoExperiments.AnExperiment, user)
switch anExperiment.groupName {
case .test:
    texts.append("\(anExperiment.name): Test Group")
    break
    
case .none:
    fallthrough
case .control:
    texts.append("\(anExperiment.name): Control Group")
    break
}
```



## Strictly Typed Experiment Values

Its also possible to define the value object to be of a given type by adding a decodable type to the definition

```swift
struct SdkDemoTypedAnotherExperiment: TypedExperiment {
    static var name = "another_experiment"
    
    var groupName: SdkDemoTypedAnotherExperimentGroup?
    enum SdkDemoTypedAnotherExperimentGroup: String, TypedGroupName {
        case control = "Control"
        case testOne = "Test One"
        case testTwo = "Test Two"
    }
    
    var value: AnotherExperimentValue? // <---- Value must now be AnotherExperimentValue
    struct AnotherExperimentValue: Decodable {
        let aString: String
        let aBool: Bool

        enum CodingKeys: String, CodingKey {
            case aString = "a_string"
            case aBool = "a_bool"
        }
    }
}
```

Then you can use the value with the strict typing:
```swift
let anotherExperiment = Statsig.shared.typed.getExperiment(SdkDemoExperiments.AnotherExperiment, user)
      
if anotherExperiment.value?.aBool === true {
    // Do Something
}
```


### Experiment Memoization (Freezing/Locking)

By setting the `isMemoizable` field in your `TypedExperiment` to return `true`. Statsig typed will only evaluate the experiment once, repeated calls to the same experiment will return the same result.

If you would like the memoization to break when a specific ID type is changed in the StatsigUser, you can set the `memoUnitIdType` field in your `TypedExperiment`. 

For example, if you set the `memoUnitIdType` to 'userID':

```swift 

struct SdkDemoTypedAnExperiment: TypedExperiment {
    static var name = "an_experiment"
    static var isMemoizable = true
    static var memoUnitIdType = "userID" // <- Set ID Type
 
    // ...
}


let statsig = Statsig.shared
statsig.setGlobalUser(StatsigUser(userID: "a-user"))

let exp1 = statsig.typed.getExperiment(SdkDemoExperiments.AnExperiment)
let exp2 = statsig.typed.getExperiment(SdkDemoExperiments.AnExperiment) // will be the same as exp2

statsig.setGlobalUser(StatsigUser(userID: "b-user"))

let exp3 = statsig.typed.getExperiment(SdkDemoExperiments.AnExperiment) // will be re-evaluated against "b-user"
```

